### PR TITLE
Default true options.sourceMap

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ UglifyJsParallelPlugin.prototype.onWorkerMessage = function(msg) {
 	}, this);
 
 	if (msg.source) {
-		this.assets[msg.file] = this.assets[msg.file].__UglifyJsPlugin = this.options.sourceMap ?
+		this.assets[msg.file] = this.assets[msg.file].__UglifyJsPlugin = (this.options.sourceMap !== false) ?
 			new SourceMapSource(msg.source, msg.file, JSON.parse(msg.map), msg.input, msg.inputSourceMap) :
 			new RawSource(msg.source);
 	}


### PR DESCRIPTION
Standard UglifyJsPlugin defaults sourceMap to `true`, and webpack-uglify-parallel does so everywhere else, but in this one spot a `this.options.sourceMap` value of `undefined` gets the same treatment as a `false`.

Your plugin has saved my team lots of waiting time since we adopted it, so many thanks!
